### PR TITLE
Improve research depth and defaults

### DIFF
--- a/backend/agent/api.py
+++ b/backend/agent/api.py
@@ -108,8 +108,8 @@ def update_env_file(var: str, value: str) -> None:
 
 class AgentStartRequest(BaseModel):
     model_name: Optional[str] = None  # Will be set from config.MODEL_TO_USE in the endpoint
-    enable_thinking: Optional[bool] = False
-    reasoning_effort: Optional[str] = 'low'
+    enable_thinking: Optional[bool] = True
+    reasoning_effort: Optional[str] = 'medium'
     stream: Optional[bool] = True
     enable_context_manager: Optional[bool] = False
 
@@ -673,8 +673,8 @@ async def generate_and_update_project_name(project_id: str, prompt: str):
 async def initiate_agent_with_files(
     prompt: str = Form(...),
     model_name: Optional[str] = Form(None),  # Default to None to use config.MODEL_TO_USE
-    enable_thinking: Optional[bool] = Form(False),
-    reasoning_effort: Optional[str] = Form("low"),
+    enable_thinking: Optional[bool] = Form(True),
+    reasoning_effort: Optional[str] = Form("medium"),
     stream: Optional[bool] = Form(True),
     enable_context_manager: Optional[bool] = Form(False),
     files: List[UploadFile] = File(default=[]),

--- a/backend/agent/prompt.py
+++ b/backend/agent/prompt.py
@@ -479,6 +479,7 @@ Your approach is deliberately methodical and persistent:
 - Use prose and paragraphs by default; only employ lists when explicitly requested by users
 - All writing must be highly detailed with a minimum length of several thousand words, unless user explicitly specifies length or format requirements
 - When writing based on references, actively cite original text with sources and provide a reference list with URLs at the end
+- Provide in-depth analysis by consulting multiple reputable sources whenever possible, cross-checking facts and citing each source
 - Focus on creating high-quality, cohesive documents directly rather than producing multiple intermediate files
 - Prioritize efficiency and document quality over quantity of files created
 - Use flowing paragraphs rather than lists; provide detailed content with proper citations

--- a/backend/agent/prompt.txt
+++ b/backend/agent/prompt.txt
@@ -465,6 +465,7 @@ Your approach is deliberately methodical and persistent:
 - Use prose and paragraphs by default; only employ lists when explicitly requested by users
 - All writing must be highly detailed with a minimum length of several thousand words, unless user explicitly specifies length or format requirements
 - When writing based on references, actively cite original text with sources and provide a reference list with URLs at the end
+- Provide in-depth analysis by consulting multiple reputable sources whenever possible, cross-checking facts and citing each source
 - Focus on creating high-quality, cohesive documents directly rather than producing multiple intermediate files
 - Prioritize efficiency and document quality over quantity of files created
 - Use flowing paragraphs rather than lists; provide detailed content with proper citations

--- a/frontend/src/app/(dashboard)/agents/[threadId]/page.tsx
+++ b/frontend/src/app/(dashboard)/agents/[threadId]/page.tsx
@@ -493,9 +493,14 @@ export default function ThreadPage({
           message 
         });
         
-        const agentPromise = startAgentMutation.mutateAsync({ 
-          threadId, 
-          options 
+        const agentPromise = startAgentMutation.mutateAsync({
+          threadId,
+          options: {
+            model_name: options?.model_name,
+            enable_thinking: options?.enable_thinking ?? true,
+            reasoning_effort: 'medium',
+            stream: true,
+          },
         });
 
         const results = await Promise.allSettled([messagePromise, agentPromise]);

--- a/frontend/src/app/(dashboard)/dashboard/page.tsx
+++ b/frontend/src/app/(dashboard)/dashboard/page.tsx
@@ -83,11 +83,21 @@ function DashboardContent() {
       });
 
       // Append options
-      if (options?.model_name) formData.append('model_name', options.model_name);
-      formData.append('enable_thinking', String(options?.enable_thinking ?? false));
-      formData.append('reasoning_effort', options?.reasoning_effort ?? 'low');
+      if (options?.model_name)
+        formData.append('model_name', options.model_name);
+      formData.append(
+        'enable_thinking',
+        String(options?.enable_thinking ?? true),
+      );
+      formData.append(
+        'reasoning_effort',
+        options?.reasoning_effort ?? 'medium',
+      );
       formData.append('stream', String(options?.stream ?? true));
-      formData.append('enable_context_manager', String(options?.enable_context_manager ?? false));
+      formData.append(
+        'enable_context_manager',
+        String(options?.enable_context_manager ?? false),
+      );
 
       console.log('FormData content:', Array.from(formData.entries()));
 
@@ -178,7 +188,11 @@ function DashboardContent() {
 
       <div className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 w-[650px] max-w-[90%]">
         <div className="flex flex-col items-center text-center mb-2 w-full">
-          <h1 className={cn('tracking-tight text-4xl font-semibold leading-tight')}>
+          <h1
+            className={cn(
+              'tracking-tight text-4xl font-semibold leading-tight',
+            )}
+          >
             Hey
           </h1>
           <p className="tracking-tight text-3xl font-normal text-muted-foreground/80 mt-2 flex items-center gap-2">

--- a/frontend/src/components/home/sections/hero-section.tsx
+++ b/frontend/src/components/home/sections/hero-section.tsx
@@ -130,6 +130,8 @@ export function HeroSection() {
       // 4. Start the agent with the thread ID
       await startAgent(thread.thread_id, {
         stream: true,
+        enable_thinking: true,
+        reasoning_effort: 'medium',
       });
 
       // 5. Navigate to the new agent's thread page


### PR DESCRIPTION
## Summary
- set `enable_thinking` and `reasoning_effort` defaults to encourage deeper reasoning
- clarify writing guidelines in the system prompt
- pass thinking defaults from frontend when starting agents
- adjust hero and dashboard pages to use the new defaults
- ensure existing threads start the agent with increased reasoning

## Testing
- `python -m py_compile backend/agent/api.py`
- `npx prettier -w frontend/src/app/(dashboard)/agents/[threadId]/page.tsx`
- `npx prettier -w frontend/src/lib/api.ts frontend/src/components/home/sections/hero-section.tsx "frontend/src/app/(dashboard)/dashboard/page.tsx"`
