### PR TITLE
Add profiling and metrics with browser toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Next.js/React application providing a responsive UI with chat interface, dashboa
 
 ### Agent Docker
 
-Isolated execution environment for every agent - with browser automation, code interpreter, file system access, tool integration, and security features.
+Isolated execution environment for every agent - with browser automation, code interpreter, file system access, tool integration, and security features. Browser automation can introduce overhead, so it can be disabled by setting `ENABLE_BROWSER_TOOL=false` in the backend environment.
 
 ### Supabase Database
 

--- a/backend/agent/api.py
+++ b/backend/agent/api.py
@@ -22,6 +22,7 @@ from services.billing import check_billing_status, can_use_model
 from utils.config import config
 from sandbox.sandbox import create_sandbox, get_or_start_sandbox
 from services.llm import make_llm_api_call
+from utils.profiling import profile
 from run_agent_background import run_agent_background, _cleanup_redis_response_list, update_agent_run_status
 
 # Initialize shared resources
@@ -316,7 +317,10 @@ async def add_llm_provider(request: AddProviderRequest, user_id: str = Depends(g
 
     return {"status": "success", "alias": alias, "model": model}
 
+from utils.profiling import profile
+
 @router.post("/thread/{thread_id}/agent/start")
+@profile
 async def start_agent(
     thread_id: str,
     body: AgentStartRequest = Body(...),
@@ -670,6 +674,7 @@ async def generate_and_update_project_name(project_id: str, prompt: str):
         logger.info(f"Finished background naming task for project: {project_id}")
 
 @router.post("/agent/initiate", response_model=InitiateAgentResponse)
+@profile
 async def initiate_agent_with_files(
     prompt: str = Form(...),
     model_name: Optional[str] = Form(None),  # Default to None to use config.MODEL_TO_USE

--- a/backend/agent/run.py
+++ b/backend/agent/run.py
@@ -16,7 +16,6 @@ from agentpress.thread_manager import ThreadManager
 from agentpress.response_processor import ProcessorConfig
 from agent.tools.sb_shell_tool import SandboxShellTool
 from agent.tools.sb_files_tool import SandboxFilesTool
-from agent.tools.sb_browser_tool import SandboxBrowserTool
 from agent.tools.data_providers_tool import DataProvidersTool
 from agent.prompt import get_system_prompt
 from utils.logger import logger
@@ -64,7 +63,14 @@ async def run_agent(
     # This ensures each tool independently verifies it's operating on the correct project
     thread_manager.add_tool(SandboxShellTool, project_id=project_id, thread_manager=thread_manager)
     thread_manager.add_tool(SandboxFilesTool, project_id=project_id, thread_manager=thread_manager)
-    thread_manager.add_tool(SandboxBrowserTool, project_id=project_id, thread_id=thread_id, thread_manager=thread_manager)
+    if config.ENABLE_BROWSER_TOOL:
+        from agent.tools.sb_browser_tool import SandboxBrowserTool
+        thread_manager.add_tool(
+            SandboxBrowserTool,
+            project_id=project_id,
+            thread_id=thread_id,
+            thread_manager=thread_manager,
+        )
     thread_manager.add_tool(SandboxDeployTool, project_id=project_id, thread_manager=thread_manager)
     thread_manager.add_tool(SandboxExposeTool, project_id=project_id, thread_manager=thread_manager)
     thread_manager.add_tool(MessageTool) # we are just doing this via prompt as there is no need to call it as a tool
@@ -116,46 +122,47 @@ async def run_agent(
         temporary_message = None
         temp_message_content_list = [] # List to hold text/image blocks
 
-        # Get the latest browser_state message
-        latest_browser_state_msg = await client.table('messages').select('*').eq('thread_id', thread_id).eq('type', 'browser_state').order('created_at', desc=True).limit(1).execute()
-        if latest_browser_state_msg.data and len(latest_browser_state_msg.data) > 0:
-            try:
-                browser_content = json.loads(latest_browser_state_msg.data[0]["content"])
-                screenshot_base64 = browser_content.get("screenshot_base64")
-                screenshot_url = browser_content.get("screenshot_url")
-                
-                # Create a copy of the browser state without screenshot data
-                browser_state_text = browser_content.copy()
-                browser_state_text.pop('screenshot_base64', None)
-                browser_state_text.pop('screenshot_url', None)
+        if config.ENABLE_BROWSER_TOOL:
+            # Get the latest browser_state message only when the browser tool is enabled
+            latest_browser_state_msg = await client.table('messages').select('*').eq('thread_id', thread_id).eq('type', 'browser_state').order('created_at', desc=True).limit(1).execute()
+            if latest_browser_state_msg.data and len(latest_browser_state_msg.data) > 0:
+                try:
+                    browser_content = json.loads(latest_browser_state_msg.data[0]["content"])
+                    screenshot_base64 = browser_content.get("screenshot_base64")
+                    screenshot_url = browser_content.get("screenshot_url")
 
-                if browser_state_text:
-                    temp_message_content_list.append({
-                        "type": "text",
-                        "text": f"The following is the current state of the browser:\n{json.dumps(browser_state_text, indent=2)}"
-                    })
-                    
-                # Prioritize screenshot_url if available
-                if screenshot_url:
-                    temp_message_content_list.append({
-                        "type": "image_url",
-                        "image_url": {
-                            "url": screenshot_url,
-                        }
-                    })
-                elif screenshot_base64:
-                    # Fallback to base64 if URL not available
-                    temp_message_content_list.append({
-                        "type": "image_url",
-                        "image_url": {
-                            "url": f"data:image/jpeg;base64,{screenshot_base64}",
-                        }
-                    })
-                else:
-                    logger.warning("Browser state found but no screenshot data.")
+                    # Create a copy of the browser state without screenshot data
+                    browser_state_text = browser_content.copy()
+                    browser_state_text.pop('screenshot_base64', None)
+                    browser_state_text.pop('screenshot_url', None)
 
-            except Exception as e:
-                logger.error(f"Error parsing browser state: {e}")
+                    if browser_state_text:
+                        temp_message_content_list.append({
+                            "type": "text",
+                            "text": f"The following is the current state of the browser:\n{json.dumps(browser_state_text, indent=2)}"
+                        })
+
+                    # Prioritize screenshot_url if available
+                    if screenshot_url:
+                        temp_message_content_list.append({
+                            "type": "image_url",
+                            "image_url": {
+                                "url": screenshot_url,
+                            }
+                        })
+                    elif screenshot_base64:
+                        # Fallback to base64 if URL not available
+                        temp_message_content_list.append({
+                            "type": "image_url",
+                            "image_url": {
+                                "url": f"data:image/jpeg;base64,{screenshot_base64}",
+                            }
+                        })
+                    else:
+                        logger.warning("Browser state found but no screenshot data.")
+
+                except Exception as e:
+                    logger.error(f"Error parsing browser state: {e}")
 
         # Get the latest image_context message (NEW)
         latest_image_context_msg = await client.table('messages').select('*').eq('thread_id', thread_id).eq('type', 'image_context').order('created_at', desc=True).limit(1).execute()

--- a/backend/api.py
+++ b/backend/api.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, Response
 from contextlib import asynccontextmanager
 from agentpress.thread_manager import ThreadManager
 from services.supabase import DBConnection
@@ -12,6 +12,7 @@ from utils.logger import logger
 import uuid
 import time
 from collections import OrderedDict
+from prometheus_client import Counter, Histogram, generate_latest, CONTENT_TYPE_LATEST
 
 # Import the agent API module
 from agent import api as agent_api
@@ -25,6 +26,18 @@ load_dotenv()
 db = DBConnection()
 thread_manager = None
 instance_id = "single"
+
+# Prometheus metrics for observability
+REQUEST_COUNT = Counter(
+    "api_request_total",
+    "Total API requests",
+    ["method", "endpoint", "http_status"],
+)
+REQUEST_LATENCY = Histogram(
+    "api_request_latency_seconds",
+    "API request latency",
+    ["method", "endpoint"],
+)
 
 # Rate limiter state
 ip_tracker = OrderedDict()
@@ -97,14 +110,18 @@ async def log_requests_middleware(request: Request, call_next):
     
     # Log the incoming request
     logger.info(f"Request started: {method} {path} from {client_ip} | Query: {query_params}")
-    
+
     try:
         response = await call_next(request)
         process_time = time.time() - start_time
+        REQUEST_LATENCY.labels(method, path).observe(process_time)
+        REQUEST_COUNT.labels(method, path, response.status_code).inc()
         logger.debug(f"Request completed: {method} {path} | Status: {response.status_code} | Time: {process_time:.2f}s")
         return response
     except Exception as e:
         process_time = time.time() - start_time
+        REQUEST_LATENCY.labels(method, path).observe(process_time)
+        REQUEST_COUNT.labels(method, path, 500).inc()
         logger.error(f"Request failed: {method} {path} | Error: {str(e)} | Time: {process_time:.2f}s")
         raise
 
@@ -145,6 +162,12 @@ async def health_check():
         "timestamp": datetime.now(timezone.utc).isoformat(),
         "instance_id": instance_id
     }
+
+@app.get("/metrics")
+async def metrics():
+    """Expose Prometheus metrics."""
+    data = generate_latest()
+    return Response(content=data, media_type=CONTENT_TYPE_LATEST)
 
 if __name__ == "__main__":
     import uvicorn

--- a/backend/run_agent_background.py
+++ b/backend/run_agent_background.py
@@ -13,6 +13,7 @@ from services.supabase import DBConnection
 from services import redis
 from dramatiq.brokers.rabbitmq import RabbitmqBroker
 import os
+from utils.profiling import profile
 
 rabbitmq_host = os.getenv('RABBITMQ_HOST', 'rabbitmq')
 rabbitmq_port = int(os.getenv('RABBITMQ_PORT', 5672))
@@ -43,6 +44,7 @@ async def initialize():
 
 
 @dramatiq.actor
+@profile
 async def run_agent_background(
     agent_run_id: str,
     thread_id: str,

--- a/backend/utils/config.py
+++ b/backend/utils/config.py
@@ -161,6 +161,9 @@ class Configuration:
     # Sandbox configuration
     SANDBOX_IMAGE_NAME = "kortix/suna:0.1.2.8"
     SANDBOX_ENTRYPOINT = "/usr/bin/supervisord -n -c /etc/supervisor/conf.d/supervisord.conf"
+    # Toggle to enable or disable the browser tool. Disabling this tool can
+    # significantly reduce overhead when browser automation is not required.
+    ENABLE_BROWSER_TOOL: bool = True
 
     @property
     def STRIPE_PRODUCT_ID(self) -> str:

--- a/backend/utils/profiling.py
+++ b/backend/utils/profiling.py
@@ -1,0 +1,39 @@
+import cProfile
+import pstats
+import io
+import asyncio
+from functools import wraps
+from utils.logger import logger
+
+
+def profile(func):
+    """Decorator to profile a function and log the top cumulative results."""
+
+    if asyncio.iscoroutinefunction(func):
+        @wraps(func)
+        async def async_wrapper(*args, **kwargs):
+            pr = cProfile.Profile()
+            pr.enable()
+            try:
+                return await func(*args, **kwargs)
+            finally:
+                pr.disable()
+                s = io.StringIO()
+                pstats.Stats(pr, stream=s).sort_stats("cumulative").print_stats(20)
+                logger.debug(f"Profiling results for {func.__name__}:\n{s.getvalue()}")
+
+        return async_wrapper
+    else:
+        @wraps(func)
+        def sync_wrapper(*args, **kwargs):
+            pr = cProfile.Profile()
+            pr.enable()
+            try:
+                return func(*args, **kwargs)
+            finally:
+                pr.disable()
+                s = io.StringIO()
+                pstats.Stats(pr, stream=s).sort_stats("cumulative").print_stats(20)
+                logger.debug(f"Profiling results for {func.__name__}:\n{s.getvalue()}")
+
+        return sync_wrapper


### PR DESCRIPTION
## Summary
- expose Prometheus metrics and profile heavy endpoints
- make browser tool optional via `ENABLE_BROWSER_TOOL`
- add profiling decorator and instrument main agent endpoints
- document new environment variable

## Testing
- `python -m py_compile backend/utils/config.py backend/agent/run.py backend/api.py backend/run_agent_background.py backend/utils/profiling.py backend/agent/api.py`
