### PR TITLE
Improve sandbox tool performance

### DIFF
--- a/backend/agent/api.py
+++ b/backend/agent/api.py
@@ -1045,7 +1045,7 @@ async def initiate_agent_with_files(
 
         # 3. Create Sandbox
         sandbox_pass = str(uuid.uuid4())
-        sandbox = create_sandbox(sandbox_pass, project_id)
+        sandbox = await create_sandbox(sandbox_pass, project_id)
         sandbox_id = sandbox.id
         logger.info(f"Created new sandbox {sandbox_id} for project {project_id}")
 

--- a/backend/utils/profiling.py
+++ b/backend/utils/profiling.py
@@ -1,3 +1,4 @@
+import os
 import cProfile
 import pstats
 import io
@@ -5,9 +6,20 @@ import asyncio
 from functools import wraps
 from utils.logger import logger
 
+# Allow profiling to be toggled via an environment variable. This lets us avoid
+# the heavy overhead of cProfile in production where every request was being
+# profiled, leading to noticeable latency. Profiling can be enabled by setting
+# `ENABLE_PROFILING=1` in the environment.
+ENABLE_PROFILING = os.getenv("ENABLE_PROFILING", "0") in {"1", "true", "True"}
+
 
 def profile(func):
     """Decorator to profile a function and log the top cumulative results."""
+
+    # If profiling is disabled, simply return the original function to avoid
+    # any overhead.
+    if not ENABLE_PROFILING:
+        return func
 
     if asyncio.iscoroutinefunction(func):
         @wraps(func)


### PR DESCRIPTION
## Summary
- avoid blocking the event loop when waiting for shell commands
- execute sandbox process calls in threads
- make sandbox creation async
- run filesystem operations using asyncio.to_thread

## Testing
- `pytest -q` *(fails: command not found)*