### PR TITLE
Improve logging and web search resilience

### DIFF
--- a/backend/agent/tools/web_search_tool.py
+++ b/backend/agent/tools/web_search_tool.py
@@ -94,7 +94,12 @@ class SandboxWebSearchTool(SandboxToolsBase):
         tag_name="web-search",
         mappings=[
             {"param_name": "query", "node_type": "attribute", "path": "."},
-            {"param_name": "num_results", "node_type": "attribute", "path": "."}
+            {
+                "param_name": "num_results",
+                "node_type": "attribute",
+                "path": ".",
+                "required": False,
+            },
         ],
         example='''
         <!-- 
@@ -155,10 +160,12 @@ class SandboxWebSearchTool(SandboxToolsBase):
             if cached is not None:
                 logging.info("Returning cached web search result")
                 search_response = cached
+                elapsed = 0.0
             else:
                 logging.info(
                     f"Executing web search for query: '{query}' with {num_results} results"
                 )
+                start_time = time.time()
                 search_response = await self.tavily_client.search(
                     query=query,
                     max_results=num_results,
@@ -166,7 +173,12 @@ class SandboxWebSearchTool(SandboxToolsBase):
                     include_answer="advanced",
                     search_depth="advanced",
                 )
+                elapsed = time.time() - start_time
                 await _search_cache.set(cache_key, search_response)
+
+            logging.info(
+                f"Web search completed in {elapsed:.2f}s for query: '{query}'"
+            )
             
             # Return the complete Tavily response 
             # This includes the query, answer, results, images and more

--- a/backend/services/llm.py
+++ b/backend/services/llm.py
@@ -300,14 +300,16 @@ async def make_llm_api_call(
         reasoning_effort=reasoning_effort
     )
     last_error = None
-    start_time = time.time()
     for attempt in range(MAX_RETRIES):
         try:
             logger.debug(f"Attempt {attempt + 1}/{MAX_RETRIES}")
             # logger.debug(f"API request parameters: {json.dumps(params, indent=2)}")
 
+            attempt_start = time.time()
             response = await litellm.acompletion(**params)
-            LLM_CALL_LATENCY.labels(model_name).observe(time.time() - start_time)
+            elapsed = time.time() - attempt_start
+            LLM_CALL_LATENCY.labels(model_name).observe(elapsed)
+            logger.info(f"LLM API call to {model_name} took {elapsed:.2f}s")
             logger.debug(f"Successfully received API response from {model_name}")
             logger.debug(f"Response: {response}")
             return response


### PR DESCRIPTION
## Summary
- make `num_results` optional for the web search tool
- measure elapsed time for web search queries
- log LLM API call durations

## Testing
- `pytest`