### PR TITLE
Improve logging and web search resilience

### DIFF
--- a/backend/services/http_client.py
+++ b/backend/services/http_client.py
@@ -1,0 +1,17 @@
+import httpx
+from typing import Optional
+
+_client: Optional[httpx.AsyncClient] = None
+
+async def get_http_client() -> httpx.AsyncClient:
+    global _client
+    if _client is None:
+        limits = httpx.Limits(max_keepalive_connections=20, max_connections=100)
+        _client = httpx.AsyncClient(http2=True, limits=limits)
+    return _client
+
+async def close_http_client() -> None:
+    global _client
+    if _client is not None:
+        await _client.aclose()
+        _client = None

--- a/backend/services/llm.py
+++ b/backend/services/llm.py
@@ -300,14 +300,16 @@ async def make_llm_api_call(
         reasoning_effort=reasoning_effort
     )
     last_error = None
-    start_time = time.time()
     for attempt in range(MAX_RETRIES):
         try:
             logger.debug(f"Attempt {attempt + 1}/{MAX_RETRIES}")
             # logger.debug(f"API request parameters: {json.dumps(params, indent=2)}")
 
+            attempt_start = time.time()
             response = await litellm.acompletion(**params)
-            LLM_CALL_LATENCY.labels(model_name).observe(time.time() - start_time)
+            elapsed = time.time() - attempt_start
+            LLM_CALL_LATENCY.labels(model_name).observe(elapsed)
+            logger.info(f"LLM API call to {model_name} took {elapsed:.2f}s")
             logger.debug(f"Successfully received API response from {model_name}")
             logger.debug(f"Response: {response}")
             return response

--- a/backend/services/supabase.py
+++ b/backend/services/supabase.py
@@ -4,6 +4,7 @@ Centralized database connection management for AgentPress using Supabase.
 
 from typing import Optional
 from supabase import create_async_client, AsyncClient
+from services.http_client import get_http_client
 from utils.logger import logger
 from utils.config import config
 import base64
@@ -41,7 +42,12 @@ class DBConnection:
                 raise RuntimeError("SUPABASE_URL and a key (SERVICE_ROLE_KEY or ANON_KEY) environment variables must be set.")
 
             logger.debug("Initializing Supabase connection")
-            self._client = await create_async_client(supabase_url, supabase_key)
+            http_client = await get_http_client()
+            self._client = await create_async_client(
+                supabase_url,
+                supabase_key,
+                http_client=http_client,
+            )
             self._initialized = True
             key_type = "SERVICE_ROLE_KEY" if config.SUPABASE_SERVICE_ROLE_KEY else "ANON_KEY"
             logger.debug(f"Database connection initialized with Supabase using {key_type}")

--- a/backend/utils/cache.py
+++ b/backend/utils/cache.py
@@ -1,0 +1,33 @@
+from collections import OrderedDict
+import asyncio
+import time
+from typing import Any
+
+class TTLCache:
+    """A simple async-safe TTL cache."""
+
+    def __init__(self, maxsize: int = 100, ttl: int = 60):
+        self.maxsize = maxsize
+        self.ttl = ttl
+        self._store = OrderedDict()
+        self._lock = asyncio.Lock()
+
+    async def get(self, key: str) -> Any:
+        async with self._lock:
+            item = self._store.get(key)
+            if item is None:
+                return None
+            value, ts = item
+            if time.time() - ts > self.ttl:
+                del self._store[key]
+                return None
+            self._store.move_to_end(key)
+            return value
+
+    async def set(self, key: str, value: Any):
+        async with self._lock:
+            if key in self._store:
+                self._store.move_to_end(key)
+            self._store[key] = (value, time.time())
+            if len(self._store) > self.maxsize:
+                self._store.popitem(last=False)


### PR DESCRIPTION
## Summary
- make `num_results` optional for the web search tool
- measure elapsed time for web search queries
- log LLM API call durations
- add shared HTTP client with keep-alive
- cache LLM message queries and sandbox instances

## Testing
- `pytest -q`
